### PR TITLE
Media query tweaks

### DIFF
--- a/index.html
+++ b/index.html
@@ -121,7 +121,7 @@
                 
                 <!-- Place image of the city in this element -->
                 <img src="" alt="" id="cityImage">
-
+               
                 <!-- Place the city summary in this <p> -->
                 <p id="citySummary"></p>
 

--- a/index.html
+++ b/index.html
@@ -252,9 +252,6 @@
                 Made by <a href="https://github.com/maxtclaw" target="_blank">Max L.</a> 
                 & 
                 <a href="https://chxw.dev" target="_blank">Chow C.</a> 
-                with the 
-                <a href="https://developers.teleport.org/api/" target="_blank">Teleport API</a>
-                <i class="fa-solid fa-circle-nodes" aria-hidden="true"></i>
                 at Juno College
             </p>
         </div>

--- a/script.js
+++ b/script.js
@@ -150,7 +150,7 @@ qualityApp.displaySummary = (continentName, cityName, cityAPIScore, citySummary)
     
     cityNameElement.innerHTML = `<h2>${cityName} (${continentName})</h2>`;
 
-    cityAPIScoreElement.textContent = `Overall Score: ${cityAPIScore.toFixed(1)} / 100`;
+    cityAPIScoreElement.innerHTML = `Overall Score: <span>${cityAPIScore.toFixed(1)} / 100</span>`;
 
     // This is used to strip extra <p> and <b> tags in the citySummary from the API
     citySummaryElement.innerHTML = citySummary;

--- a/styles/sass/partials/_jsClasses.scss
+++ b/styles/sass/partials/_jsClasses.scss
@@ -1,4 +1,6 @@
-//class to hide stuff
+//kabob cases are JS exclusive CSS classes 
+
+//class to hide stuff 
 .hidden {
     display: none;
 }

--- a/styles/sass/partials/_mediaQueries.scss
+++ b/styles/sass/partials/_mediaQueries.scss
@@ -5,6 +5,10 @@
         text-align: center;
     }
 
+    header {
+        padding-top: 100px;
+    }
+
     .headerInfoContainer {
         flex-direction: column;
         align-items: center;
@@ -51,6 +55,17 @@
 @media only screen and (max-width: 500px) {
     .wrapper {
         width: 95%;
+    }
+
+    .results {
+        h3 span {
+            display: block;
+        }
+
+        img {
+            height: 300px;
+            object-fit: cover;
+        }
     }
 
     .categoryContainer {

--- a/styles/style.css
+++ b/styles/style.css
@@ -684,6 +684,9 @@ footer .wrapper {
   h1 {
     text-align: center;
   }
+  header {
+    padding-top: 100px;
+  }
   .headerInfoContainer {
     -webkit-box-orient: vertical;
     -webkit-box-direction: normal;
@@ -734,6 +737,14 @@ footer .wrapper {
 @media only screen and (max-width: 500px) {
   .wrapper {
     width: 95%;
+  }
+  .results h3 span {
+    display: block;
+  }
+  .results img {
+    height: 300px;
+    -o-object-fit: cover;
+       object-fit: cover;
   }
   .categoryContainer {
     width: 100%;


### PR DESCRIPTION
- padding-top to 1000px at 1000px width so less empty space at top
- made city image bigger on smaller screens (500px and down)
- put score in a span and made it a block element at 500px to avoid it running on a new line
- footer sentence shorter